### PR TITLE
[SQUASH] Settings: Allow scheduling always on display [2/2]

### DIFF
--- a/res/values/afterlife_arrays.xml
+++ b/res/values/afterlife_arrays.xml
@@ -12,4 +12,21 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+
+    <!-- AOD Schedule -->
+    <string-array name="doze_always_on_auto_mode_entries">
+        <item>@string/string_disabled</item>
+        <item>@string/night_display_auto_mode_twilight</item>
+        <item>@string/always_on_display_schedule_mixed_sunset</item>
+        <item>@string/always_on_display_schedule_mixed_sunrise</item>
+        <item>@string/night_display_auto_mode_custom</item>
+    </string-array>
+
+    <string-array name="doze_always_on_auto_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
+        <item>4</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/res/values/afterlife_strings.xml
+++ b/res/values/afterlife_strings.xml
@@ -233,4 +233,12 @@
 
     <!-- Screenshot shutter -->
     <string name="screenshot_shutter_sound_title">Screenshot sound</string>
+
+    <!-- AOD Schedule -->
+    <string name="always_on_display_schedule_title">Always on display schedule</string>
+    <string name="string_disabled">Disabled</string>
+    <string name="always_on_display_schedule_sunset">Sunset</string>
+    <string name="always_on_display_schedule_sunrise">Sunrise</string>
+    <string name="always_on_display_schedule_mixed_sunset">Turns on from sunset till a time</string>
+    <string name="always_on_display_schedule_mixed_sunrise">Turns on from a time till sunrise</string>
 </resources>

--- a/res/xml/always_on_display_schedule.xml
+++ b/res/xml/always_on_display_schedule.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2021 Yet Another AOSP Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/always_on_display_schedule_title">
+
+    <ListPreference
+        android:key="doze_always_on_auto_mode"
+        android:title="@string/night_display_auto_mode_title"
+        android:dialogTitle="@string/night_display_auto_mode_title"
+        android:entries="@array/doze_always_on_auto_mode_entries"
+        android:entryValues="@array/doze_always_on_auto_mode_values"
+        android:persistent="false" />
+
+    <Preference
+        android:key="doze_always_on_auto_since"
+        android:title="@string/night_display_start_time_title" />
+
+    <Preference
+        android:key="doze_always_on_auto_till"
+        android:title="@string/night_display_end_time_title" />
+
+</PreferenceScreen>

--- a/res/xml/security_lockscreen_settings.xml
+++ b/res/xml/security_lockscreen_settings.xml
@@ -103,6 +103,12 @@
             settings:controller="com.android.settings.gestures.TapScreenGesturePreferenceController" />
 
         <Preference
+            android:key="always_on_display_schedule"
+            android:title="@string/always_on_display_schedule_title"
+            android:fragment="com.android.settings.display.AODSchedule"
+            settings:controller="com.android.settings.display.AODSchedulePreferenceController" />
+
+        <Preference
             android:key="ambient_display_double_tap"
             android:title="@string/ambient_display_title"
             android:fragment="com.android.settings.gestures.DoubleTapScreenSettings"

--- a/src/com/android/settings/display/AODSchedule.java
+++ b/src/com/android/settings/display/AODSchedule.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2021 Yet Another AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import static com.android.settings.display.AODSchedulePreferenceController.MODE_DISABLED;
+import static com.android.settings.display.AODSchedulePreferenceController.MODE_NIGHT;
+import static com.android.settings.display.AODSchedulePreferenceController.MODE_TIME;
+import static com.android.settings.display.AODSchedulePreferenceController.MODE_MIXED_SUNSET;
+import static com.android.settings.display.AODSchedulePreferenceController.MODE_MIXED_SUNRISE;
+
+import android.app.TimePickerDialog;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.text.format.DateFormat;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.search.SearchIndexable;
+
+import java.time.format.DateTimeFormatter;
+import java.time.LocalTime;
+
+@SearchIndexable
+public class AODSchedule extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceClickListener, Preference.OnPreferenceChangeListener {
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.always_on_display_schedule);
+
+    private static final String MODE_KEY = "doze_always_on_auto_mode";
+    private static final String SINCE_PREF_KEY = "doze_always_on_auto_since";
+    private static final String TILL_PREF_KEY = "doze_always_on_auto_till";
+
+    private ListPreference mModePref;
+    private Preference mSincePref;
+    private Preference mTillPref;
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.always_on_display_schedule;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.EVOLVER;
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+
+        mSincePref = findPreference(SINCE_PREF_KEY);
+        mSincePref.setOnPreferenceClickListener(this);
+        mTillPref = findPreference(TILL_PREF_KEY);
+        mTillPref.setOnPreferenceClickListener(this);
+
+        final int mode = Settings.Secure.getIntForUser(getActivity().getContentResolver(),
+                MODE_KEY, MODE_DISABLED, UserHandle.USER_CURRENT);
+        mModePref = findPreference(MODE_KEY);
+        mModePref.setValue(String.valueOf(mode));
+        mModePref.setSummary(mModePref.getEntry());
+        mModePref.setOnPreferenceChangeListener(this);
+
+        updateTimeEnablement(mode);
+        updateTimeSummary(mode);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        final int value = Integer.parseInt((String) objValue);
+        final int index = mModePref.findIndexOfValue((String) objValue);
+        mModePref.setSummary(mModePref.getEntries()[index]);
+        Settings.Secure.putIntForUser(getActivity().getContentResolver(),
+                MODE_KEY, value, UserHandle.USER_CURRENT);
+        updateTimeEnablement(value);
+        updateTimeSummary(value);
+        return true;
+    }
+
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        final String[] times = getCustomTimeSetting();
+        final boolean isSince = preference == mSincePref;
+        final int hour, minute;
+        if (isSince) {
+            final String[] sinceValues = times[0].split(":", 0);
+            hour = Integer.parseInt(sinceValues[0]);
+            minute = Integer.parseInt(sinceValues[1]);
+        } else {
+            final String[] tillValues = times[1].split(":", 0);
+            hour = Integer.parseInt(tillValues[0]);
+            minute = Integer.parseInt(tillValues[1]);
+        }
+        final TimePickerDialog.OnTimeSetListener listener = (view, hourOfDay, minute1) ->
+                updateTimeSetting(isSince, hourOfDay, minute1);
+        final TimePickerDialog dialog = new TimePickerDialog(getContext(), listener,
+                hour, minute, DateFormat.is24HourFormat(getContext()));
+        dialog.show();
+        return true;
+    }
+
+    private String[] getCustomTimeSetting() {
+        final String value = Settings.Secure.getStringForUser(getActivity().getContentResolver(),
+                Settings.Secure.DOZE_ALWAYS_ON_AUTO_TIME, UserHandle.USER_CURRENT);
+        if (value == null || value.isEmpty()) return new String[] { "20:00", "07:00" };
+        return value.split(",", 0);
+    }
+
+    private void updateTimeEnablement(int mode) {
+        mSincePref.setEnabled(mode == MODE_TIME || mode == MODE_MIXED_SUNRISE);
+        mTillPref.setEnabled(mode == MODE_TIME || mode == MODE_MIXED_SUNSET);
+    }
+
+    private void updateTimeSummary(int mode) {
+        updateTimeSummary(getCustomTimeSetting(), mode);
+    }
+
+    private void updateTimeSummary(String[] times, int mode) {
+        if (mode == MODE_DISABLED) {
+            mSincePref.setSummary("-");
+            mTillPref.setSummary("-");
+            return;
+        }
+
+        if (mode == MODE_NIGHT) {
+            mSincePref.setSummary(R.string.always_on_display_schedule_sunset);
+            mTillPref.setSummary(R.string.always_on_display_schedule_sunrise);
+            return;
+        }
+
+        final String outputFormat = DateFormat.is24HourFormat(getContext()) ? "HH:mm" : "hh:mm a";
+        final DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern(outputFormat);
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        final LocalTime sinceDT = LocalTime.parse(times[0], formatter);
+        final LocalTime tillDT = LocalTime.parse(times[1], formatter);
+
+        if (mode == MODE_MIXED_SUNSET) {
+            mSincePref.setSummary(R.string.always_on_display_schedule_sunset);
+            mTillPref.setSummary(tillDT.format(outputFormatter));
+        } else if (mode == MODE_MIXED_SUNRISE) {
+            mTillPref.setSummary(R.string.always_on_display_schedule_sunrise);
+            mSincePref.setSummary(sinceDT.format(outputFormatter));
+        } else {
+            mSincePref.setSummary(sinceDT.format(outputFormatter));
+            mTillPref.setSummary(tillDT.format(outputFormatter));
+        }
+    }
+
+    private void updateTimeSetting(boolean since, int hour, int minute) {
+        final String[] times = getCustomTimeSetting();
+        String nHour = "";
+        String nMinute = "";
+        if (hour < 10) nHour += "0";
+        if (minute < 10) nMinute += "0";
+        nHour += String.valueOf(hour);
+        nMinute += String.valueOf(minute);
+        times[since ? 0 : 1] = nHour + ":" + nMinute;
+        Settings.Secure.putStringForUser(getActivity().getContentResolver(),
+                Settings.Secure.DOZE_ALWAYS_ON_AUTO_TIME,
+                times[0] + "," + times[1], UserHandle.USER_CURRENT);
+        updateTimeSummary(times, Integer.parseInt(mModePref.getValue()));
+    }
+}

--- a/src/com/android/settings/display/AODSchedulePreferenceController.kt
+++ b/src/com/android/settings/display/AODSchedulePreferenceController.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 Yet Another AOSP Project
+ * Copyright (C) 2022 FlamingoOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.android.settings.display
+
+import android.content.Context
+import android.hardware.display.AmbientDisplayConfiguration
+import android.os.SystemProperties
+import android.os.UserHandle
+import android.provider.Settings
+
+import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
+
+class AODSchedulePreferenceController(
+    context: Context,
+    key: String,
+) : BasePreferenceController(context, key) {
+
+    private var ambientDisplayConfig: AmbientDisplayConfiguration? = null
+
+    override fun getAvailabilityStatus() =
+        if (isAODAvailable()) AVAILABLE else UNSUPPORTED_ON_DEVICE
+
+    override fun getSummary(): CharSequence {
+        val mode = Settings.Secure.getIntForUser(mContext.contentResolver,
+                Settings.Secure.DOZE_ALWAYS_ON_AUTO_MODE, 0, UserHandle.USER_CURRENT)
+        return when (mode) {
+            MODE_NIGHT -> mContext.getString(R.string.night_display_auto_mode_twilight)
+            MODE_TIME -> mContext.getString(R.string.night_display_auto_mode_custom)
+            MODE_MIXED_SUNSET -> mContext.getString(R.string.always_on_display_schedule_mixed_sunset)
+            MODE_MIXED_SUNRISE -> mContext.getString(R.string.always_on_display_schedule_mixed_sunrise)
+            else -> mContext.getString(R.string.string_disabled)
+        }
+    }
+
+    fun setConfig(config: AmbientDisplayConfiguration): AODSchedulePreferenceController {
+        ambientDisplayConfig = config
+        return this
+    }
+
+    private fun getConfig(): AmbientDisplayConfiguration {
+        if (ambientDisplayConfig == null) {
+            ambientDisplayConfig = AmbientDisplayConfiguration(mContext)
+        }
+        return ambientDisplayConfig!!
+    }
+
+    private fun isAODAvailable(): Boolean {
+        return getConfig().alwaysOnAvailableForUser(UserHandle.myUserId()) &&
+            !SystemProperties.getBoolean(PROP_AWARE_AVAILABLE, false)
+    }
+
+    companion object {
+        const val MODE_DISABLED = 0
+        const val MODE_NIGHT = 1
+        const val MODE_TIME = 2
+        const val MODE_MIXED_SUNSET = 3
+        const val MODE_MIXED_SUNRISE = 4
+
+        private const val PROP_AWARE_AVAILABLE = "ro.vendor.aware_available"
+    }
+}

--- a/src/com/android/settings/security/LockscreenDashboardFragment.java
+++ b/src/com/android/settings/security/LockscreenDashboardFragment.java
@@ -30,11 +30,13 @@ import android.os.Looper;
 import android.provider.Settings;
 
 import androidx.annotation.VisibleForTesting;
+import androidx.preference.Preference;
 
 import com.android.settings.R;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.display.AmbientDisplayAlwaysOnPreferenceController;
 import com.android.settings.display.AmbientDisplayNotificationsPreferenceController;
+import com.android.settings.display.AODSchedulePreferenceController;
 import com.android.settings.gestures.DoubleTapScreenPreferenceController;
 import com.android.settings.gestures.PickupGesturePreferenceController;
 import com.android.settings.notification.LockScreenNotificationPreferenceController;
@@ -53,9 +55,6 @@ import java.util.List;
 @SearchIndexable
 public class LockscreenDashboardFragment extends DashboardFragment
         implements OwnerInfoPreferenceController.OwnerInfoCallback {
-
-    public static final String KEY_AMBIENT_DISPLAY_ALWAYS_ON = "ambient_display_always_on";
-
     private static final String TAG = "LockscreenDashboardFragment";
 
     @VisibleForTesting
@@ -69,7 +68,6 @@ public class LockscreenDashboardFragment extends DashboardFragment
     @VisibleForTesting
     static final String KEY_ADD_USER_FROM_LOCK_SCREEN =
             "security_lockscreen_add_users_when_locked";
-
 
     private AmbientDisplayConfiguration mConfig;
     private OwnerInfoPreferenceController mOwnerInfoPreferenceController;
@@ -113,6 +111,8 @@ public class LockscreenDashboardFragment extends DashboardFragment
         use(AmbientDisplayNotificationsPreferenceController.class).setConfig(getConfig(context));
         use(DoubleTapScreenPreferenceController.class).setConfig(getConfig(context));
         use(PickupGesturePreferenceController.class).setConfig(getConfig(context));
+        use(ScreenOffUdfpsPreferenceController.class).setConfig(getConfig(context));
+        use(AODSchedulePreferenceController.class).setConfig(getConfig(context));
 
         mControlsContentObserver = new ContentObserver(
                 new Handler(Looper.getMainLooper())) {


### PR DESCRIPTION
* Squash of yaap/packages_apps_YASP@30441ec yaap/packages_apps_YASP@b896aa6 yaap/packages_apps_YASP@f500a60

[jhonboy121]: adapted to A13 and use a preference controller to update the preference


Change-Id: If736f5609ca660e3c9797a309c814d2dcd618d31