### PR TITLE
Setting: batteryinfo: Add config `show_battery_design_capacity` & `show_battery_maximum_capacity`

### DIFF
--- a/res/values/afterlife_configs.xml
+++ b/res/values/afterlife_configs.xml
@@ -29,6 +29,12 @@
     <!-- Show battery cycle count -->
     <bool name="config_show_battery_cycle_count" translatable="false">false</bool>
 
+    <!-- Show battery Design Capacity -->
+    <bool name="config_show_battery_design_capacity">true</bool>
+
+    <!-- Show battery Maximum Capacity -->
+    <bool name="config_show_battery_maximum_capacity">true</bool>
+
     <!-- Whether to show peak refresh rate in display settings -->
     <bool name="config_show_peak_refresh_rate_switch">false</bool>
 

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryDesignCapacityPreferenceController extends BasePreferenceCon
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_design_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
@@ -35,7 +35,8 @@ public class BatteryMaximumCapacityPreferenceController extends BasePreferenceCo
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        boolean isFeatureEnabled = mContext.getResources().getBoolean(R.bool.config_show_battery_maximum_capacity);
+        return isFeatureEnabled ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override


### PR DESCRIPTION
* Legacy devices like the Pixel 2 Series do not support this, only show Unavailable for design capacity and maximum capacity in battery information.
* Enabled by default